### PR TITLE
The widget breaks with anonymous users

### DIFF
--- a/phileo/templates/phileo/_widget.html
+++ b/phileo/templates/phileo/_widget.html
@@ -1,4 +1,6 @@
 <div class="phileo">
-    <a class="{{ toggle_class }}" id="{{ like_link }}"></a>
+	{% if not user.is_anonymous: %}
+		<a class="{{ toggle_class }}" id="{{ like_link }}"></a>
+	{% endif %}
     <span class="{{ like_span_total }}">{{ likes_count }}</span>
 </div>

--- a/phileo/templatetags/phileo_tags.py
+++ b/phileo/templatetags/phileo_tags.py
@@ -88,19 +88,25 @@ def likes_widget(user, obj, like_link_id="likes", like_span_total_class="phileo-
 @register.inclusion_tag("phileo/_script.html")
 def likes_js(user, obj, like_link="#likes", like_span_total=".phileo-count", toggle_class="phileo-liked"):
     ct = ContentType.objects.get_for_model(obj)
-    url = reverse("phileo_like_toggle", kwargs={
-        "content_type_id": ct.id,
-        "object_id": obj.pk
-    })
-    liked = Like.objects.filter(
-       sender = user,
-       receiver_content_type = ContentType.objects.get_for_model(obj),
-       receiver_object_id = obj.pk
-    ).exists()
+    if user.is_anonymous():
+        liked = False
+        like_url = settings.LOGIN_URL
+    else:
+        url = reverse("phileo_like_toggle", kwargs={
+            "content_type_id": ct.id,
+            "object_id": obj.pk
+        })
+        liked = Like.objects.filter(
+           sender = user,
+           receiver_content_type = ContentType.objects.get_for_model(obj),
+           receiver_object_id = obj.pk
+        ).exists()
+
     if liked:
         is_liked = toggle_class
     else:
         is_liked = ""
+
     return {
         "STATIC_URL": settings.STATIC_URL,
         "like_url": url,


### PR DESCRIPTION
Anonymous users do not have the `likes` collection, so the widget breaks. I added a check for anonymous users, which
1. Does not break the view when the user is anonymous
2. Does not render the 'like' button when the user is anonymous. The count is still shown
