### PR TITLE
Correct the jQuery plugin loading order

### DIFF
--- a/phileo/static/phileo/js/jquery.phileo.js
+++ b/phileo/static/phileo/js/jquery.phileo.js
@@ -1,4 +1,5 @@
-jQuery(function($) {
+!function($){
+    "use strict";
 
     var PhileoLikes = function(form, options) {
         this.options = $.extend({}, $.fn.phileo.defaults, options);
@@ -36,4 +37,4 @@ jQuery(function($) {
         toggle_class: 'phileo-liked',
         count: false
     };
-});
+}( window.jQuery || window.ender );


### PR DESCRIPTION
The phileo plugin was added to jQuery in the domready event callback. As
this plugin could be loaded at the bottom of a page - AFTER phileo
widget scripts - it was possible for the phileo plugin to not be
loaded when the widgets were initialized in the domready event. As the
phileo plugin does not need the DOM to be ready to set itself up, the
plugin now loads as the page is loading. This allows phileo widgets to
be inserted before the phileo plugin script and for everything to still
work.
