### PR TITLE
Fix doc bug

### DIFF
--- a/docs/templatetags.rst
+++ b/docs/templatetags.rst
@@ -22,7 +22,7 @@ An assignment tag that fetches a list of likes for a given object::
     {% who_likes car as car_likes %}
     
     {% for like in car_likes %}
-        <div class="like">{{ like.user }} likes {{ car }}</div>
+        <div class="like">{{ like.sender.get_full_name }} likes {{ car }}</div>
     {% endfor %}
 
 


### PR DESCRIPTION
Unless I'm missing something (which is totally possible), I think the user who liked something is the `sender`, not `user`. Using `user` I get nothing.
