### PR TITLE
Robustifying and expanding tests.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,6 @@ MANIFEST
 .eggs
 docs/_build/
 htmlcov/
-
+.python-version
 # Pycharm
 .idea

--- a/pinax/likes/tests/test_views.py
+++ b/pinax/likes/tests/test_views.py
@@ -1,100 +1,270 @@
 import json
-
-from django.test import TestCase, RequestFactory
+import mock
 
 from django.contrib.auth.models import AnonymousUser, User
 from django.contrib.contenttypes.models import ContentType
+from django.core.urlresolvers import reverse
+from django.http import Http404
+from django.test import RequestFactory, TestCase
+from django.utils.http import urlquote
 
 from ..models import Like
-from ..views import LikeToogleView
+from ..views import LikeToggleView
 
 
 class LikeToggleTestCase(TestCase):
 
     def setUp(self):
+        self.user_content_type = ContentType.objects.get(model="user")
         self.factory = RequestFactory()
         self.user = User.objects.create(username="patrick")
         self.other_users = []
-        self.user_content_type = ContentType.objects.get(model="user")
         for other_user in ["james", "brian", "michael", "tom", "yulka"]:
             self.other_users.append(
                 User.objects.create(username=other_user)
             )
-        Like.objects.create(
+
+        # Create a LIKE from Patrick for James.
+        james = User.objects.get(username="james")
+        self.original_like = Like.objects.create(
             sender=self.user,
             receiver_content_type=self.user_content_type,
-            receiver_object_id=self.other_users[0].pk
+            receiver_object_id=james.pk
         )
-        self.like_qs = Like.objects.filter(sender=self.user, receiver_content_type=self.user_content_type)
+        self.like_qs = Like.objects.filter(
+            sender=self.user,
+            receiver_content_type=self.user_content_type
+
+        )
 
     def test_like_brian(self):
+        """
+        Ensure logged-in user can like another user.
+        """
         brian = User.objects.get(username="brian")
-        request = self.factory.post("/like/{0}:{1}/".format(self.user_content_type.pk, brian.pk))
+        url = reverse(
+            "pinax_likes:like_toggle",
+            kwargs=dict(
+                content_type_id=self.user_content_type.pk,
+                object_id=brian.pk
+            )
+        )
+        request = self.factory.post(url)
         request.user = self.user
-        response = LikeToogleView.as_view()(request, self.user_content_type.pk, brian.pk)
-        self.assertEquals(response.status_code, 302)
-        self.assertTrue(self.like_qs.filter(receiver_object_id=brian.pk).exists())
 
-    def test_like_brian_unauthed(self):
+        self.assertFalse(self.like_qs.filter(receiver_object_id=brian.pk).exists())
+
+        with mock.patch('pinax.likes.signals.object_liked.send', autospec=True) as mocked_handler:
+            response = LikeToggleView.as_view()(
+                request,
+                content_type_id=self.user_content_type.pk,
+                object_id=brian.pk
+            )
+            self.assertEqual(response.status_code, 302)
+            self.assertTrue(self.like_qs.filter(receiver_object_id=brian.pk).exists())
+            # Ensure signal handler was called with proper arguments.
+            like = self.like_qs.get(receiver_object_id=brian.pk)
+            self.assertEquals(mocked_handler.call_count, 1)
+            mocked_handler.assert_called_with(sender=Like, like=like, request=request)
+
+    def test_unauthed_like_brian(self):
+        """
+        Ensure anonymous user cannot like another user.
+        """
         brian = User.objects.get(username="brian")
-        request = self.factory.post("/like/{0}:{1}/".format(self.user_content_type.pk, brian.pk))
+        url = reverse(
+            "pinax_likes:like_toggle",
+            kwargs=dict(
+                content_type_id=self.user_content_type.pk,
+                object_id=brian.pk
+            )
+        )
+        request = self.factory.post(url)
         request.user = AnonymousUser()
-        response = LikeToogleView.as_view()(request, self.user_content_type.pk, brian.pk)
-        self.assertEquals(response.status_code, 302)
-        self.assertEquals(response.url, "/accounts/login/?next=/like/3%3A3/")
+        response = LikeToggleView.as_view()(
+            request,
+            content_type_id=self.user_content_type.pk,
+            object_id=brian.pk
+        )
+        self.assertEqual(response.status_code, 302)
+        encoded_url = urlquote(url)
+        # Response (redirect) URL path comes from pinax/likes/tests/urls.py
+        self.assertEqual(response.url, "/dummy_login/?next={}".format(encoded_url))
         self.assertFalse(self.like_qs.filter(receiver_object_id=brian.pk).exists())
 
     def test_unlike_james(self):
+        """
+        Ensure a liked object is unliked.
+        """
         james = User.objects.get(username="james")
-        request = self.factory.post("/like/{0}:{1}/".format(self.user_content_type.pk, james.pk))
-        request.user = self.user
-        response = LikeToogleView.as_view()(request, self.user_content_type.pk, james.pk)
-        self.assertEquals(response.status_code, 302)
-        self.assertFalse(self.like_qs.filter(receiver_object_id=james.pk).exists())
-
-    def test_unlike_james_ajax(self):
-        james = User.objects.get(username="james")
-        request = self.factory.post(
-            "/like/{0}:{1}/".format(self.user_content_type.pk, james.pk),
-            HTTP_X_REQUESTED_WITH="XMLHttpRequest"
+        url = reverse(
+            "pinax_likes:like_toggle",
+            kwargs=dict(
+                content_type_id=self.user_content_type.pk,
+                object_id=james.pk
+            )
         )
+        request = self.factory.post(url)
         request.user = self.user
-        response = LikeToogleView.as_view()(request, self.user_content_type.pk, james.pk)
-        self.assertEquals(response.status_code, 200)
-        self.assertFalse(self.like_qs.filter(receiver_object_id=james.pk).exists())
-        data = json.loads(response.content.decode())
-        self.assertEquals(data["likes_count"], 0)
-        self.assertEquals(data["liked"], False)
-        self.assertTrue("html" in data)
+
+        self.assertTrue(self.like_qs.filter(receiver_object_id=james.pk).exists())
+        with mock.patch('pinax.likes.signals.object_unliked.send', autospec=True) as mocked_handler:
+            response = LikeToggleView.as_view()(
+                request,
+                content_type_id=self.user_content_type.pk,
+                object_id=james.pk
+            )
+            self.assertEqual(response.status_code, 302)
+            self.assertFalse(self.like_qs.filter(receiver_object_id=james.pk).exists())
+            # Ensure signal handler was called with proper arguments.
+            self.assertEquals(mocked_handler.call_count, 1)
+            mocked_handler.assert_called_with(sender=Like, object=james, request=request)
 
     def test_like_michael_ajax(self):
+        """
+        Ensure proper AJAX response for a like.
+        """
         michael = User.objects.get(username="michael")
-        request = self.factory.post(
-            "/like/{0}:{1}/".format(self.user_content_type.pk, michael.pk),
-            HTTP_X_REQUESTED_WITH="XMLHttpRequest"
+        url = reverse(
+            "pinax_likes:like_toggle",
+            kwargs=dict(
+                content_type_id=self.user_content_type.pk,
+                object_id=michael.pk
+            )
         )
+        request = self.factory.post(url, HTTP_X_REQUESTED_WITH="XMLHttpRequest")
         request.user = self.user
-        response = LikeToogleView.as_view()(request, self.user_content_type.pk, michael.pk)
-        self.assertEquals(response.status_code, 200)
-        self.assertTrue(self.like_qs.filter(receiver_object_id=michael.pk).exists())
-        data = json.loads(response.content.decode())
-        self.assertEquals(data["likes_count"], 1)
-        self.assertEquals(data["liked"], True)
-        self.assertTrue("html" in data)
+        with mock.patch('pinax.likes.signals.object_liked.send', autospec=True) as mocked_handler:
+            response = LikeToggleView.as_view()(
+                request,
+                content_type_id=self.user_content_type.pk,
+                object_id=michael.pk
+            )
+            self.assertEqual(response.status_code, 200)
+            self.assertTrue(self.like_qs.filter(receiver_object_id=michael.pk).exists())
+            data = json.loads(response.content.decode())
+            self.assertEqual(data["likes_count"], 1)
+            self.assertEqual(data["liked"], True)
+            self.assertTrue("html" in data)
+            # Ensure signal handler was called with proper arguments.
+            like = self.like_qs.get(receiver_object_id=michael.pk)
+            self.assertEquals(mocked_handler.call_count, 1)
+            mocked_handler.assert_called_with(sender=Like, like=like, request=request)
 
     def test_multiple_like_michael_ajax(self):
+        """
+        Ensure multiple users can like the same object.
+        """
         michael = User.objects.get(username="michael")
-        request = self.factory.post(
-            "/like/{0}:{1}/".format(self.user_content_type.pk, michael.pk),
-            HTTP_X_REQUESTED_WITH="XMLHttpRequest"
+        url = reverse(
+            "pinax_likes:like_toggle",
+            kwargs=dict(
+                content_type_id=self.user_content_type.pk,
+                object_id=michael.pk
+            )
         )
+        request = self.factory.post(url, HTTP_X_REQUESTED_WITH="XMLHttpRequest")
         request.user = self.user
-        response = LikeToogleView.as_view()(request, self.user_content_type.pk, michael.pk)
+        response = LikeToggleView.as_view()(
+            request,
+            content_type_id=self.user_content_type.pk,
+            object_id=michael.pk
+        )
+        # Add a second LIKE
         request.user = User.objects.get(username="tom")
-        response = LikeToogleView.as_view()(request, self.user_content_type.pk, michael.pk)
-        self.assertEquals(response.status_code, 200)
+        response = LikeToggleView.as_view()(
+            request,
+            content_type_id=self.user_content_type.pk,
+            object_id=michael.pk
+        )
+        self.assertEqual(response.status_code, 200)
         self.assertTrue(self.like_qs.filter(receiver_object_id=michael.pk).exists())
         data = json.loads(response.content.decode())
-        self.assertEquals(data["likes_count"], 2)
-        self.assertEquals(data["liked"], True)
+        self.assertEqual(data["likes_count"], 2)
+        self.assertEqual(data["liked"], True)
         self.assertTrue("html" in data)
+
+    def test_unlike_james_ajax(self):
+        """
+        Ensure a liked object is unliked via AJAX.
+        """
+        james = User.objects.get(username="james")
+        url = reverse(
+            "pinax_likes:like_toggle",
+            kwargs=dict(
+                content_type_id=self.user_content_type.pk,
+                object_id=james.pk
+            )
+        )
+        request = self.factory.post(url, HTTP_X_REQUESTED_WITH="XMLHttpRequest")
+        request.user = self.user
+        with mock.patch('pinax.likes.signals.object_unliked.send', autospec=True) as mocked_handler:
+            response = LikeToggleView.as_view()(
+                request,
+                content_type_id=self.user_content_type.pk,
+                object_id=james.pk
+            )
+            self.assertEqual(response.status_code, 200)
+            self.assertFalse(self.like_qs.filter(receiver_object_id=james.pk).exists())
+            data = json.loads(response.content.decode())
+            self.assertEqual(data["likes_count"], 0)
+            self.assertEqual(data["liked"], False)
+            self.assertTrue("html" in data)
+            # Ensure signal handler was called with proper arguments.
+            self.assertEquals(mocked_handler.call_count, 1)
+            mocked_handler.assert_called_with(sender=Like, object=james, request=request)
+
+    def test_like_unlikeable_object(self):
+        """
+        Ensure proper error response when liking an unlikeable model.
+        """
+        # Test settings do not permit liking a models.Like instance.
+        like_content_type = ContentType.objects.get(model="like")
+        url = reverse(
+            "pinax_likes:like_toggle",
+            kwargs=dict(
+                content_type_id=like_content_type.pk,
+                object_id=self.original_like.pk
+            )
+        )
+        request = self.factory.post(url)
+        request.user = self.user
+        response = LikeToggleView.as_view()(
+            request,
+            content_type_id=like_content_type.pk,
+            object_id=self.original_like.pk
+        )
+        self.assertEqual(response.status_code, 403)
+
+    def test_like_bad_content_type(self):
+        """
+        Ensure we raise 404 when liking a bad ContentType.
+        """
+        url = reverse(
+            "pinax_likes:like_toggle",
+            kwargs=dict(
+                content_type_id=12345,
+                object_id=1
+            )
+        )
+        request = self.factory.post(url)
+        request.user = self.user
+        with self.assertRaises(Http404):
+            LikeToggleView.as_view()(request, content_type_id=12345, object_id=1)
+
+    def test_like_bad_object_id(self):
+        url = reverse(
+            "pinax_likes:like_toggle",
+            kwargs=dict(
+                content_type_id=self.user_content_type.pk,
+                object_id=555
+            )
+        )
+        request = self.factory.post(url)
+        request.user = self.user
+        with self.assertRaises(Http404):
+            LikeToggleView.as_view()(
+                request,
+                content_type_id=self.user_content_type.pk,
+                object_id=555
+            )

--- a/pinax/likes/tests/urls.py
+++ b/pinax/likes/tests/urls.py
@@ -1,6 +1,10 @@
 from django.conf.urls import include, url
 
 
+def dummy_view():
+    pass
+
 urlpatterns = [
-    url(r"^", include("pinax.likes.urls")),
+    url(r"^", include("pinax.likes.urls", namespace="pinax_likes")),
+    url(r"^dummy_login/$", dummy_view, name="account_login"),
 ]

--- a/pinax/likes/urls.py
+++ b/pinax/likes/urls.py
@@ -4,5 +4,7 @@ from . import views
 
 
 urlpatterns = [
-    url(r"^like/(?P<content_type_id>\d+):(?P<object_id>\d+)/$", views.LikeToogleView.as_view(), name="likes_like_toggle")
+    url(r"^like/(?P<content_type_id>\d+):(?P<object_id>\d+)/$",
+        views.LikeToggleView.as_view(),
+        name="like_toggle")
 ]

--- a/pinax/likes/utils.py
+++ b/pinax/likes/utils.py
@@ -71,7 +71,7 @@ def widget_context(user, obj):
             like_class = config["css_class_off"]
 
         ctx.update({
-            "like_url": reverse("likes_like_toggle", kwargs={
+            "like_url": reverse("pinax_likes:like_toggle", kwargs={
                 "content_type_id": ct.id,
                 "object_id": obj.pk
             }),

--- a/runtests.py
+++ b/runtests.py
@@ -44,6 +44,18 @@ DEFAULT_SETTINGS = dict(
     AUTHENTICATION_BACKENDS=[
         "pinax.likes.auth_backends.CanLikeBackend"
     ],
+    TEMPLATES=[
+        {
+            "BACKEND": "django.template.backends.django.DjangoTemplates",
+            "APP_DIRS": True,
+            "OPTIONS": {
+                "debug": True,
+                "context_processors": [
+                    "django.contrib.auth.context_processors.auth",
+                ]
+            }
+        },
+    ]
 )
 
 

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,8 @@ setup(
     license="MIT",
     packages=find_packages(),
     install_requires=[
-        "django-appconf>=0.6",
+        "django-appconf>=1.0.1",
+        "django-user-accounts>=1.3.1"
     ],
     package_data={
         "pinax.likes": [
@@ -30,6 +31,7 @@ setup(
     },
     test_suite="runtests.runtests",
     tests_require=[
+        "mock>=1.3.0",
     ],
     classifiers=[
         "Development Status :: 5 - Production/Stable",

--- a/tox.ini
+++ b/tox.ini
@@ -7,24 +7,22 @@ exclude = pinax/likes/migrations/*,docs/*
 [tox]
 envlist =
     py27-{1.8,1.9,master},
-    py32-{1.8},
     py33-{1.8},
     py34-{1.8,1.9,master},
     py35-{1.8,1.9,master}
 
 [testenv]
 deps =
-    py{27,33,34,35}: coverage==4.0.2
-    py32: coverage==3.7.1
+    coverage==4.0.2
     flake8==2.5.0
     1.8: Django>=1.8,<1.9
     1.9: Django>=1.9,<1.10
     master: https://github.com/django/django/tarball/master
 usedevelop = True
 setenv =
-   LANG=en_US.UTF-8
-   LANGUAGE=en_US:en
-   LC_ALL=en_US.UTF-8
+    LANG=en_US.UTF-8
+    LANGUAGE=en_US:en
+    LC_ALL=en_US.UTF-8
 commands =
     flake8 pinax
     coverage run setup.py test


### PR DESCRIPTION
Rename LikeToogleView.
Test signals.
Reset testing/CI configurations.
Fix LikeToggleView for Django>=1.8.

Fixes #36