### PR TITLE
Added context to likes_widget templatetag

### DIFF
--- a/pinax/likes/models.py
+++ b/pinax/likes/models.py
@@ -10,9 +10,10 @@ from django.contrib.contenttypes.models import ContentType
 @python_2_unicode_compatible
 class Like(models.Model):
 
-    sender = models.ForeignKey(settings.AUTH_USER_MODEL, related_name="liking")
+    sender = models.ForeignKey(settings.AUTH_USER_MODEL,
+                               related_name="liking", on_delete=models.CASCADE)
 
-    receiver_content_type = models.ForeignKey(ContentType)
+    receiver_content_type = models.ForeignKey(ContentType, on_delete=models.CASCADE)
     receiver_object_id = models.PositiveIntegerField()
     receiver = GenericForeignKey(
         ct_field="receiver_content_type",

--- a/pinax/likes/templatetags/pinax_likes_tags.py
+++ b/pinax/likes/templatetags/pinax_likes_tags.py
@@ -71,7 +71,7 @@ def likes_widget(context, user, obj, template_name="pinax/likes/_widget.html"):
     or
         {% likes_widget request.user post "pinax/likes/_widget_brief.html" %}
     """
-    request = context['request']
+    request = context["request"]
     return loader.get_template(template_name).render(
         widget_context(user, obj, request))
 

--- a/pinax/likes/templatetags/pinax_likes_tags.py
+++ b/pinax/likes/templatetags/pinax_likes_tags.py
@@ -62,8 +62,8 @@ def likes_count(obj):
     ).count()
 
 
-@register.simple_tag
-def likes_widget(user, obj, template_name="pinax/likes/_widget.html"):
+@register.simple_tag(takes_context=True)
+def likes_widget(context, user, obj, template_name="pinax/likes/_widget.html"):
     """
     Usage:
 
@@ -71,7 +71,9 @@ def likes_widget(user, obj, template_name="pinax/likes/_widget.html"):
     or
         {% likes_widget request.user post "pinax/likes/_widget_brief.html" %}
     """
-    return loader.get_template(template_name).render(widget_context(user, obj))
+    request = context['request']
+    return loader.get_template(template_name).render(
+        widget_context(user, obj, request))
 
 
 class LikeRenderer(template.Node):

--- a/pinax/likes/utils.py
+++ b/pinax/likes/utils.py
@@ -35,7 +35,7 @@ def per_model_perm_check(user, obj):
         return True
 
 
-def widget_context(user, obj):
+def widget_context(user, obj, request):
     ct = ContentType.objects.get_for_model(obj)
     config = get_config(obj)
     like_count = Like.objects.filter(
@@ -54,6 +54,7 @@ def widget_context(user, obj):
         "like_count": like_count,
         "counts_text": counts_text,
         "object": obj,
+        "request": request
     }
 
     if can_like:

--- a/pinax/likes/views.py
+++ b/pinax/likes/views.py
@@ -37,7 +37,7 @@ class LikeToggleView(LoginRequiredMixin, View):
             object_unliked.send(sender=Like, object=obj, request=request)
 
         if request.is_ajax():
-            html_ctx = widget_context(request.user, obj)
+            html_ctx = widget_context(request.user, obj, request)
             template = "pinax/likes/_widget.html"
             if request.GET.get("t") == "b":
                 template = "pinax/likes/_widget_brief.html"


### PR DESCRIPTION
This PR adds `takes_context` to the `likes_widget()` and `context['request']` to the context for the widget template.

Example use case for this PR is to allow use of `request.build_absolute_uri` for adding the "next" parameter to the URL of a call-to-action when the user is not authenticated.